### PR TITLE
Introduce the SAR workflow

### DIFF
--- a/devices/lavender/bootimg.cfg
+++ b/devices/lavender/bootimg.cfg
@@ -1,9 +1,8 @@
 bootsize = 0x4000000
 pagesize = 0x1000
 kerneladdr = 0x8000
-ramdiskaddr = 0x1000000
+ramdiskaddr = 0x2000000
 secondaddr = 0xf00000
 tagsaddr = 0x100
 name = 
-cmdline = console=ttyMSM0,115200,n8 androidboot.console=ttyMSM0 earlycon=msm_serial_dm,0xc170000 androidboot.hardware=qcom user_debug=31 msm_rtb.filter=0x37 ehci-hcd.park=3 lpm_levels.sleep_disabled=1 sched_enable_hmp=1 sched_enable_power_aware=1 service_locator.enable=1 swiotlb=1 androidboot.configfs=true androidboot.usbcontroller=a800000.dwc3 loop.max_part=7 skip_initramfs rootwait ro init=/init buildvariant=userdebug
-androidboot.selinux=permissive
+cmdline = console=ttyMSM0,115200,n8 androidboot.console=ttyMSM0 earlycon=msm_serial_dm,0xc170000 androidboot.hardware=qcom user_debug=31 msm_rtb.filter=0x37 ehci-hcd.park=3 lpm_levels.sleep_disabled=1 sched_enable_hmp=1 sched_enable_power_aware=1 service_locator.enable=1 swiotlb=1 androidboot.configfs=true androidboot.usbcontroller=a800000.dwc3 loop.max_part=7 buildvariant=userdebug androidboot.selinux=permissive cgroup_disable=schedtune sharkbait.device=lavender sharkbait.boot=legacy_sar

--- a/devices/lavender/initramfs/init
+++ b/devices/lavender/initramfs/init
@@ -1,15 +1,13 @@
 #!/bin/sh
 
-export PATH=/bin
-
-USERDATA=/dev/block/mmcblk0p66
+USERDATA=/dev/mmcblk0p66
 FSROOT=/mnt/userdata
 NEWROOT=$FSROOT/gnu
 NEWINIT=/sbin/init
 
 # write log to kmsg
 log() {
-	echo new_era: $@ > /dev/kmsg
+	echo "new_era: $@" > /dev/kmsg
 }
 
 die() {
@@ -17,17 +15,29 @@ die() {
 	exit 1
 }
 
-# set up psuedo-filesystems
-mount -t devtmpfs none /dev
+# set up psuedo-filesystems, /dev is already present
+mkdir /sys /proc || die Failed to make directories /sys and /proc
+
+# mount the pseudofs(s)
+mount -t proc none /proc || die Failed to mount /proc
+mount -t sysfs none /sys || die Failed to mount /sys
+mount -t tmpfs none /dev || die Failed to mount /dev
+
+# populate /dev
+mdev -s || die Failed to populate /dev
 
 log Preinit started!
 log Trying to mount $USERDATA on $FSROOT...
-mkdir -p $FSROOT
-mount -t ext4 $USERDATA $FSROOT || die Failed to mount $USERDATA
+mkdir -p $FSROOT	|| die Failed to make the directory $FSROOT
+ 
+mount $USERDATA $FSROOT || die Failed to mount $USERDATA
 
 log Setting up $NEWROOT as mountpoint...
-mount -o bind,ro $NEWROOT $NEWROOT || die Failed to setup $NEWROOT as mountpoint
+mount -r --bind $NEWROOT $NEWROOT || die Failed to setup $NEWROOT as mountpoint
 
 log Cleaning up mounts, switching root to $NEWROOT, and launching $NEWINIT...
-mount --move /dev $NEWROOT/dev
-exec switch_root $NEWROOT $NEWINIT
+mount --move /dev $NEWROOT/dev || die Failed to move /dev
+mount --move /sys $NEWROOT/sys || die Failed to move /sys
+mount --move /proc $NEWROOT/proc || die Failed to move /proc
+
+exec switch_root $NEWROOT $NEWINIT || die Failed to switch_root to $NEWINIT


### PR DESCRIPTION
This kind of merges [`sar-preinit`](https://gitlab.com/WantGuns/sar-preinit) with the original SharkBait preinit.
In order for this to work, SAR device holding porters would have to apply [this patch](https://github.com/WantGuns/android_kernel_xiaomi_sdm660/commit/dfaee4b2de0f97f1ec3e1c2713f386480d61a178.patch) into their kernel sources.

```
Changes to be committed:
   modified:   bootimg.cfg
        Introduces the `sharkbait` namespace for easier configuration of
        the SharkBait setup. Newer phones have their codenames assigned
        to different cmdline variables, the original setup would fail
        them, so `sharkbait.device` is introduced.
        The `sharkbait.boot` easily differentiates the boot order
        between ramdisk boot.img, legacy_sar boot.img and the
        ramdisk_sar boot.img variants.

    modified:   initramfs/init
        Removed the requirement of `devtmpfs` support in the Kernel.
```
P.S.
The SharkBait's porter wiki would require changes about the SAR workflow, once I introduce it in the sharkbait-setup as well.